### PR TITLE
Handle invalid input gracefully

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -44,7 +44,7 @@ class ModelWrapper(MAXModelWrapper):
             return image
         except IOError:
             e = BadRequest()
-            e.data = {'status': 'error', 'message': 'Unable to load image file'}
+            e.data = {'status': 'error', 'message': 'The input is not a valid image.'}
             raise e
 
     def _pre_process(self, image):

--- a/core/model.py
+++ b/core/model.py
@@ -6,6 +6,7 @@ from keras import models
 from keras.preprocessing.image import img_to_array
 from keras.applications import imagenet_utils
 import numpy as np
+from werkzeug.exceptions import BadRequest
 from maxfw.model import MAXModelWrapper
 from config import DEFAULT_MODEL_PATH
 
@@ -38,7 +39,13 @@ class ModelWrapper(MAXModelWrapper):
         logger.info('Loaded model: {}'.format(self.model.name))
 
     def read_image(self, image_data):
-        return Image.open(io.BytesIO(image_data))
+        try:
+            image = Image.open(io.BytesIO(image_data))
+            return image
+        except IOError:
+            e = BadRequest()
+            e.data = {'status': 'error', 'message': 'Unable to load image file'}
+            raise e
 
     def _pre_process(self, image):
         image = image.resize(self.MODEL_INPUT_IMG_SIZE)

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,6 +48,15 @@ def test_predict():
     assert response['predictions'][0]['label'] == 'cheeseburger'
     assert response['predictions'][0]['probability'] > 0.75
 
+    # Test invalid
+    file_path = 'assets/README.md'
+
+    with open(file_path, 'rb') as file:
+        file_form = {'image': (file_path, file, 'image/jpeg')}
+        r = requests.post(url=model_endpoint, files=file_form)
+
+    assert r.status_code == 400
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
return 400 for invalid images (resolves #4)

This PR replaces #16 