### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/re
 ARG model_file=assets.tar.gz
 
 WORKDIR /workspace
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
-RUN mkdir -p ~/.keras/models && mv assets/imagenet_class_index.json ~/.keras/models/imagenet_class_index.json
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file} && \
+  mkdir -p ~/.keras/models && mv assets/imagenet_class_index.json ~/.keras/models/imagenet_class_index.json
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.