### PR TITLE
Upgrade Pillow

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -70,7 +70,7 @@ class ModelWrapper(MAXModelWrapper):
             abort(400, 'Invalid file type/extension. Please provide a valid image (supported formats: JPEG, PNG, TIFF).')
 
     def _pre_process(self, image):
-        image = image.resize(self.MODEL_INPUT_IMG_SIZE)
+        image = image.resize(self.MODEL_INPUT_IMG_SIZE, resample=Image.NEAREST)
         image = img_to_array(image)
         image = np.expand_dims(image, axis=0)
         return imagenet_utils.preprocess_input(image, mode=self.MODEL_MODE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.18.1
 tensorflow==1.15.4
-Pillow==6.2.2
+Pillow==7.1.0
 h5py==2.9.0
 keras==2.1.4


### PR DESCRIPTION
This PR replaces #62 

Pillow 7.0.0 [changed the default resampling filter](https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#default-resampling-filter) which resulted in a small decrease of model accuracy causing the tests to fail.

This PR upgrades pillow and manually sets the same resample method used in Pillow 6.x.x